### PR TITLE
remove in-band options

### DIFF
--- a/lib/db/record.js
+++ b/lib/db/record.js
@@ -6,13 +6,14 @@ var Promise = require('bluebird'),
  * Insert the given record into the database.
  *
  * @param  {Object} record  The record to insert.
+ * @param  {Object} options The command options.
  * @promise {Object}        The inserted record.
  */
-exports.create = function (record) {
+exports.create = function (record, options) {
   var className = record['@class'] || '',
-      options = record['@options'] || {},
       rid, promise;
 
+  options = options || {};
   if (record['@rid']) {
     promise = Promise.resolve(record['@rid']);
   }
@@ -69,7 +70,7 @@ exports.get = function (record, options) {
       rid = extracted[0],
       record = extracted[1];
 
-  options = record['@options'] || options || {};
+  options = options || {};
 
   if (!rid) {
     return Promise.reject(new errors.Operation('Cannot read - no record id specified'));
@@ -170,23 +171,23 @@ function recordIdResolver () {
 /**
  * Read the metadata for the given record.
  *
- * @param  {Object} record The record to load.
- * @promise {Object}       The record object with loaded meta data.
+ * @param  {Object} record  The record to load.
+ * @param  {Object} options The query options.
+ * @promise {Object}        The record object with loaded meta data.
  */
-exports.meta = function (record) {
+exports.meta = function (record, options) {
   if (Array.isArray(record)) {
     return Promise.all(record.map(this.record.read, this));
   }
   var extracted = extractRecordId(record),
       rid = extracted[0],
-      record = extracted[1],
-      options = record['@options'] || {};
+      record = extracted[1];
+
+  options = options || {};
 
   if (!rid) {
     return Promise.reject(new errors.Operation('Cannot read - no record id specified'));
   }
-
-  var options = record['@options'] || {};
 
   return this.send('record-metadata', {
     cluster: rid.cluster,
@@ -203,15 +204,17 @@ exports.meta = function (record) {
 /**
  * Update the given record.
  *
- * @param  {Object} record The record to update.
- * @promise {Object}       The updated record.
+ * @param  {Object} record  The record to update.
+ * @param  {Object} options The query options.
+ * @promise {Object}        The updated record.
  */
-exports.update = function (record) {
+exports.update = function (record, options) {
   var extracted = extractRecordId(record),
       rid = extracted[0],
       record = extracted[1],
-      options = record['@options'] || {},
       promise, data;
+
+  options = options || {};
 
   if (!rid) {
     return Promise.reject(new errors.Operation('Cannot update record -  record ID is not specified or invalid.'));
@@ -247,7 +250,6 @@ exports.update = function (record) {
     data.record = record;
     return this.send('record-update', data)
     .then(function (results) {
-      delete record['@options'];
       record['@version'] = (results ? results.version : 0) || 0;
       return record;
     });
@@ -258,16 +260,18 @@ exports.update = function (record) {
  * Delete the given record.
  *
  * @param   {String|RID|Object} record  The record or record id to delete.
+ * @param   {Object}            options The query options.
  * @promise {Object}                    The deleted record object.
  */
-exports.delete = function (record) {
+exports.delete = function (record, options) {
   if (!record) {
     return Promise.reject(new errors.Operation('Cannot delete - no record specified'));
   }
   var extracted = extractRecordId(record),
       rid = extracted[0],
-      record = extracted[1],
-      options = record['@options'] || {};
+      record = extracted[1];
+
+  options = options || {};
 
   if (!rid) {
     return Promise.reject(new errors.Operation('Cannot delete - no record id specified'));

--- a/lib/protocol/serializer.js
+++ b/lib/protocol/serializer.js
@@ -27,11 +27,11 @@ function serializeDocument (document, isMap) {
   for (i = 0; i < totalFields; i++) {
     field = fieldNames[i];
     value = document[field];
-    if (field === '@version' || field === '@rid' || field === '@type' || field === '@options') {
-      continue;
-    }
-    else if (field === '@class') {
+    if (field === '@class') {
       className = value;
+    }
+    else if (field.charAt(0) === '@') {
+      continue;
     }
     else {
       if (isMap) {

--- a/test/db/record-test.js
+++ b/test/db/record-test.js
@@ -30,12 +30,7 @@ describe("Database API - Record", function () {
       });
     });
     it('should get the record with a fetch plan', function () {
-      return this.db.record.get({
-        '@rid': '#5:0',
-        '@options': {
-          fetchPlan: '*:-1'
-        }
-      })
+      return this.db.record.get({'@rid': '#5:0'}, {fetchPlan: '*:-1'})
       .then(function (record) {
         record['@class'].should.equal('OUser');
         record['@rid'].should.have.properties({
@@ -108,13 +103,7 @@ describe("Database API - Record", function () {
 
   describe('Db::record.update()', function () {
     it('should update a record', function () {
-      return this.db.record.update({
-        '@rid': createdRID,
-        '@options': {
-          preserve: true
-        },
-        name: 'testuserrenamed',
-      })
+      return this.db.record.update({'@rid': createdRID, name: 'testuserrenamed'}, {preserve: true})
       .then(function (record) {
         record.name.should.equal('testuserrenamed');
       });
@@ -158,6 +147,8 @@ describe("Database API - Record", function () {
         record.linkedTest2.should.be.an.instanceOf(LIB.RID); // a real link
       });
     });
+
+
   });
 
   describe('Db::record.meta()', function () {


### PR DESCRIPTION
Before this, it was possible for users to specify options for a record load / update in-band via an `@options` key. This would potentially have allowed malicious end users to construct requests that affected the way the records were loaded and persisted - nasty. The solution is to use a separate `options` argument.
