### PR TITLE
add test for #82

### DIFF
--- a/test/bugs/82-emojis.js
+++ b/test/bugs/82-emojis.js
@@ -1,0 +1,35 @@
+describe.only("Bug #82: db.query errors when parsing emojis ", function () {
+  var rid;
+  before(function () {
+    return CREATE_TEST_DB(this, 'testdb_bug_82')
+    .bind(this)
+    .then(function () {
+      return this.db.class.create('Emoji');
+    })
+    .then(function (item) {
+      this.class = item;
+    });
+  });
+  after(function () {
+    return DELETE_TEST_DB('testdb_bug_82');
+  });
+
+  it('should allow emojis in insert statements', function () {
+    return this.db.insert().into('Emoji').set({value: '😢😂😭'}).one()
+    .then(function (result) {
+      result.should.have.property('@rid');
+      rid = result['@rid'];
+    });
+  });
+  it('should allow emojis in update statements', function () {
+    return this.db.update(rid).set({value: 'hello 😢😂😭', foo: 'bar'}).one();
+  });
+
+  it.skip('should allow emojis using db.query() directly', function () {
+    var query = 'UPDATE ' + rid + ' SET bio="Aiming to be Miranda Kerr, Candice Swanepoel, Adriana Lima, Alessandra Ambrosio, Doutzen Kroes, Erin Heatherton, or Behati Prinsloo 😢😂 foo"';
+    return this.db.query(query)
+    .spread(function (result) {
+      result.should.equal(1);
+    });
+  });
+});


### PR DESCRIPTION
There's a problem when inserting values containing emojis in unparameterized queries. It appears that the orientdb sql parser cannot handle them and is bailing out, whereas this does not occur when using bound parameters (recommended usage). We're using a slightly older version of the orientdb _binary protocol_ (not database version) and I'm going to upgrade us to the latest version before reporting this as a bug there.

I'm going to pretend that this fixes #82 because it's a problem with orientdb and not oriento.
