### PR TITLE
#134: Adds a RETURN clause before WHERE

### DIFF
--- a/lib/db/statement.js
+++ b/lib/db/statement.js
@@ -118,17 +118,6 @@ Statement.prototype.upsert = function (condition, params, comparisonOperator) {
 };
 
 /**
- * Returning specifies what to return from the query.
- *
- * @param  {String} value  Can be COUNT | BEFORE | AFTER | @rid | @this.
- * @return {Statement}     The statement object.
- */
-Statement.prototype.returning = function (value) {
-  this._state.returning = value;
-  return this;
-};
-
-/**
  * Specify the where clause for the statement.
  *
  * @param  {String|String[]} args The where clause
@@ -243,13 +232,15 @@ Statement.prototype.commit = function (retryLimit) {
 };
 
 /**
- * Return a certain variable.
+ * Return a certain variable if there is a let clause.
+ * For update, insert or delete statements it will add a RETURN clause before
+ * the WHERE clause.
  *
- * @param  {String} name The name of the variable to return.
+ * @param  {String} value The name of the variable or what to return.
  * @return {Statement}   The statement object.
  */
-Statement.prototype.return = function (name) {
-  this._state.return = name;
+Statement.prototype.return = function (value) {
+  this._state.return = value;
   return this;
 };
 
@@ -401,8 +392,8 @@ Statement.prototype.buildStatement = function () {
     statement.push('UPSERT');
   }
   
-  if (state.returning) {
-    statement.push('RETURN ' + state.returning);
+  if ((state.update || state.insert || state.delete) && state.return) {
+    statement.push('RETURN ' + state.return);
   }
 
   if (state.where) {
@@ -497,7 +488,7 @@ Statement.prototype.buildStatement = function () {
     statement.push('\n');
   }
 
-  if (state.return) {
+  if (!(state.update || state.insert || state.delete) && state.return) {
     statement.push('RETURN ' + state.return);
   }
   return statement.join(' ');

--- a/test/db/statement-test.js
+++ b/test/db/statement-test.js
@@ -124,6 +124,16 @@ COMMIT \n\
       .should
       .equal('BEGIN\n LET names = UPDATE OUser SET name = "name"\n \nCOMMIT \n RETURN $names');
     });
+    it('should generate an update transaction, with returns and a return clause before while', function () {
+      var sub = (new Statement(this.db)).update('OUser').set({name: 'name'}).return('COUNT');
+      this.statement
+      .let('names', sub)
+      .commit()
+      .return('$names')
+      .toString()
+      .should
+      .equal('BEGIN\n LET names = UPDATE OUser SET name = "name" RETURN COUNT\n \nCOMMIT \n RETURN $names');
+    });
   });
 
   describe('Statement::select()', function () {
@@ -181,17 +191,6 @@ COMMIT \n\
       this.statement.buildStatement().should.equal('SELECT * FROM (SELECT * FROM OUser)');
     });
   });
-  
-  describe('Statement::returning()', function () {
-    it('should build a return clause', function () {
-      this.statement.update('#1:1').set({foo: 'bar', greeting: 'hello world'}).returning('AFTER');
-      this.statement.buildStatement().should.equal('UPDATE #1:1 SET foo = :paramfoo0, greeting = :paramgreeting1 RETURN AFTER');
-    });
-    it('should build a return clause before the where clause', function () {
-      this.statement.update('#1:1').set({foo: 'bar', greeting: 'hello world'}).returning('AFTER').where('1=1');
-      this.statement.buildStatement().should.equal('UPDATE #1:1 SET foo = :paramfoo0, greeting = :paramgreeting1 RETURN AFTER WHERE 1=1');
-    });
-  });
 
   describe('Statement::to()', function () {
     it('should create an edge', function () {
@@ -201,6 +200,21 @@ COMMIT \n\
     it('should create an edge from a record id to a record id', function () {
       this.statement.create('EDGE', 'E').from(LIB.RID('#5:0')).to(LIB.RID('#22:310540'));
       this.statement.buildStatement().should.equal('CREATE EDGE E FROM #5:0 TO #22:310540');
+    });
+  });
+
+  describe('Statement::return()', function () {
+    it('should build a return clause', function () {
+      this.statement.update('#1:1').set({foo: 'bar', greeting: 'hello world'}).return('AFTER');
+      this.statement.buildStatement().should.equal('UPDATE #1:1 SET foo = :paramfoo0, greeting = :paramgreeting1 RETURN AFTER');
+    });
+    it('should build a return clause before the where clause', function () {
+      this.statement.delete().from('OUser').return('BEFORE').where({foo: 'bar', greeting: 'hello world'});
+      this.statement.buildStatement().should.equal('DELETE FROM OUser RETURN BEFORE WHERE (foo = :paramfoo0 AND greeting = :paramgreeting1)');
+    });
+    it('should build a return clause after the insert query', function () {
+      this.statement.insert().into('OUser').set({foo: 'bar', greeting: 'hello world'}).return('AFTER');
+      this.statement.buildStatement().should.equal('INSERT INTO OUser SET foo = :paramfoo0, greeting = :paramgreeting1 RETURN AFTER');
     });
   });
 


### PR DESCRIPTION
Adds a return clause before where as per OrientDB's documentation (https://github.com/orientechnologies/orientdb/wiki/SQL-Update). The choice of "returning" was made to avoid conflict with the already existing "return".

Issue #134
