### PR TITLE
Binary transport - destroy socket during close

### DIFF
--- a/lib/transport/binary/connection.js
+++ b/lib/transport/binary/connection.js
@@ -133,7 +133,10 @@ Connection.prototype.createSocket = function () {
  */
 Connection.prototype.close = function () {
   if (this.socket) {
-    this.socket.end();
+    //this.socket.end();
+    // to avoid hangup of process we need to destroy socket completely.
+    this.socket.removeAllListeners();
+    this.socket.destroy();
     this.socket = null;
   }
   return this;
@@ -219,7 +222,7 @@ Connection.prototype.negotiateProtocol = function () {
     }.bind(this));
     this.socket.once('close', function (err) {
       this.logger.debug('connection closed during protocol negotiation: ' + err);
-      this.socket.removeAllListeners();
+      if (this.socket) this.socket.removeAllListeners(); // close earlier could have destroyed set socket to null. 
       this.connecting = false;
       if (err) {
         reject(new errors.Connection(err.code, err.message));


### PR DESCRIPTION
Using socket.end is hanging the process - socket.destroy with case-handling seem to be making it work.

Refer: http://nodejs.org/api/net.html#net_socket_destroy vs http://nodejs.org/api/net.html#net_socket_end_data_encoding
