### PR TITLE
update property for mandatory and notNull

### DIFF
--- a/lib/db/class/property.js
+++ b/lib/db/class/property.js
@@ -215,10 +215,10 @@ Property.update = function (property, reload) {
     promises.push(this.db.exec(prefix + 'TYPE ' + property.type));
   }
   if (property.mandatory !== undefined) {
-    promises.push(this.db.exec(prefix + 'MANDATORY ' + (property.mandatory ? 'true' : 'false')));
+    promises.push(this.db.exec(prefix + 'MANDATORY ' + (property.mandatory != 0 || property.mandatory || "false")));
   }
   if (property.notNull !== undefined) {
-    promises.push(this.db.exec(prefix + 'NOTNULL ' + (property.notNull ? 'true' : 'false')));
+    promises.push(this.db.exec(prefix + 'NOTNULL ' + (property.notNull != 0 || property.notNull || "false")));
   }
 
   if (property.custom) {


### PR DESCRIPTION
The current implementation checks if mandtory / notNull are true or false and then maps this to "true" or false like so: (property.mandatory ? 'true' : 'false'). However this implies that the string "false" will be mapped to "true". On the other side calling the driver to list the properties reports both mandatory and notNull as strings. So retrieving the properties and writing them back to the DB will always set mandatory and notNull to "true". It is also not consistent with the behaviour of the other properties which are concatenated as a string to the query statement. Replacing it with (property.mandatory ||'false') would map 1 to false (which mapped formerly to "true"). The suggested fix would map integers somewhat reasonable to "true" and "false". Null and undefined would map to "false". Strings would be just concatenated. It follows that "false" would now now map to "false" and "unreasonable input" would result in a db error.
