### PR TITLE
add db.registerTransformer()

### DIFF
--- a/lib/db/index.js
+++ b/lib/db/index.js
@@ -52,6 +52,7 @@ Db.prototype.configure = function (config) {
   this.password = config.password || 'admin';
   this.dataSegments = [];
   this.transactionId = 0;
+  this.transformers = config.transformers || {};
   return this;
 };
 
@@ -302,12 +303,41 @@ Db.prototype.normalizeResultContent = function (content) {
       cluster: content.cluster,
       position: content.position
     });
+    if (value['@class']) {
+      return this.transformDocument(value);
+    }
     return value;
   }
   else {
     return content;
   }
 };
+
+Db.prototype.registerTransformer = function (className, transformer) {
+  this.transformers[className] = this.transformers[className] || [];
+  this.transformers[className].push(transformer);
+  return this;
+};
+
+
+/**
+ * Transform a document according to its `@class` property, using the registered transformers.
+ * @param  {Object} document The document to transform.
+ * @return {Mixed}           The transformed document.
+ */
+Db.prototype.transformDocument = function (document) {
+  var className = document['@class'];
+  if (this.transformers[className]) {
+    return this.transformers[className].reduce(function (document, transformer) {
+      return transformer(document);
+    }, document);
+  }
+  else {
+    return document;
+  }
+};
+
+
 
 // # Query Builder Methods
 

--- a/test/db/db-test.js
+++ b/test/db/db-test.js
@@ -1,3 +1,5 @@
+var Promise = require('bluebird');
+
 describe("Database API", function () {
   before(function () {
     return TEST_SERVER.create({
@@ -69,6 +71,85 @@ describe("Database API", function () {
       .then(function (response) {
         response.length.should.equal(1);
         response[0].name.should.equal('writer');
+      });
+    });
+  });
+
+  describe('Db::registerTransformer()', function () {
+    function OUser (data) {
+      if (!(this instanceof OUser)) {
+        return new OUser(data);
+      }
+      var keys = Object.keys(data),
+          length = keys.length,
+          key, i;
+      for (i = 0; i < length; i++) {
+        key = keys[i];
+        this[key] = data[key];
+      }
+    }
+
+    function ORole (data) {
+      if (!(this instanceof ORole)) {
+        return new ORole(data);
+      }
+      var keys = Object.keys(data),
+          length = keys.length,
+          key, i;
+      for (i = 0; i < length; i++) {
+        key = keys[i];
+        this[key] = data[key];
+      }
+    }
+
+
+    before(function () {
+      this.db.registerTransformer('OUser', OUser);
+      this.db.registerTransformer('ORole', ORole);
+    });
+
+    it('should register a transformation function for a class', function () {
+      return Promise.all([
+        this.db.select().from('OUser').all(),
+        this.db.select().from('ORole').all()
+      ])
+      .spread(function (users, roles) {
+        users.length.should.be.above(0);
+        users.forEach(function (user) {
+          user.should.be.an.instanceOf(OUser);
+        });
+        roles.length.should.be.above(0);
+        roles.forEach(function (role) {
+          role.should.be.an.instanceOf(ORole);
+        });
+      });
+    });
+
+    it('should transform documents even when they are nested', function () {
+      return this.db.select().from('OUser').fetch({roles: 1}).all()
+      .then(function (users) {
+        users.length.should.be.above(0);
+        users.forEach(function (user) {
+          user.should.be.an.instanceOf(OUser);
+          user.roles.length.should.be.above(0);
+          user.roles.forEach(function (role) {
+            role.should.be.an.instanceOf(ORole);
+          });
+        });
+      });
+    });
+
+    it('should still allow scalars', function () {
+      return this.db.select().from('OUser').limit(1).scalar()
+      .then(function (result) {
+        result.should.equal('admin');
+      });
+    });
+
+    it('should not transform when individual columns are selected', function () {
+      return this.db.select('name, status').from('OUser').limit(1).one()
+      .then(function (result) {
+        result.should.not.be.an.instanceOf(OUser);
       });
     });
   });


### PR DESCRIPTION
allows registering transformers at the database level, can be used to automatically convert documents into model instances according to their class, e.g.

``` js
var UserModel = require('./models/user');

db.registerTransformer('OUser', UserModel);

db.select().from('OUser').limit(1).one().then(function (user) {
  user instanceof UserModel; // true, assuming UserModel supports instantiation without `new`
});

```
