### PR TITLE
add selective disabling of ridbags

### DIFF
--- a/lib/transport/binary/connection.js
+++ b/lib/transport/binary/connection.js
@@ -17,6 +17,9 @@ function Connection (config) {
   this.logger = config.logger || {debug: function () {}};
   this.setMaxListeners(Infinity);
 
+
+  this.enableRIDBags = config.enableRIDBags || true;
+
   this.protocol = null;
   this.queue = [];
   this.writes = [];
@@ -195,6 +198,7 @@ Connection.prototype.negotiateProtocol = function () {
       else {
         this.protocol = require('./protocol19');
       }
+      this.protocol.deserializer.enableRIDBags = this.enableRIDBags;
       resolve(this);
       this.connecting = false;
       this.bindToSocket();

--- a/lib/transport/binary/index.js
+++ b/lib/transport/binary/index.js
@@ -46,6 +46,8 @@ BinaryTransport.prototype.configure = function (config) {
   this.username = config.username || 'root';
   this.password = config.password || '';
 
+  this.enableRIDBags = config.enableRIDBags || true;
+
   this.sessionId = -1;
   this.configureLogger(config.logger || {});
   if (config.pool) {
@@ -81,6 +83,7 @@ BinaryTransport.prototype.configureConnection = function () {
   this.connection = new Connection({
     host: this.host,
     port: this.port,
+    enableRIDBags: this.enableRIDBags,
     logger: this.logger
   });
   this.connection.on('update-config', function (config) {
@@ -109,6 +112,7 @@ BinaryTransport.prototype.configurePool = function (config) {
   this.pool = new ConnectionPool({
     host: this.host,
     port: this.port,
+    enableRIDBags: this.enableRIDBags,
     logger: this.logger,
     max: config.max
   });

--- a/lib/transport/binary/protocol19/deserializer.js
+++ b/lib/transport/binary/protocol19/deserializer.js
@@ -491,7 +491,12 @@ function eatBag (input) {
   }
   input = input.slice(i + 1);
 
-  return [new Bag(collected), input];
+  if (exports.enableRIDBags) {
+    return [new Bag(collected), input];
+  }
+  else {
+    return [new Bag(collected).all(), input];
+  }
 }
 
 
@@ -521,7 +526,7 @@ function eatBinary (input) {
 }
 
 
-
+exports.enableRIDBags = true;
 exports.deserialize = deserialize;
 exports.eatKey = eatKey;
 exports.eatValue = eatValue;

--- a/lib/transport/binary/protocol26/deserializer.js
+++ b/lib/transport/binary/protocol26/deserializer.js
@@ -230,8 +230,8 @@ function eatNumber (input) {
 
   num = input.match(pattern);
   if (num) {
-  	collected = num[0];
-  	i = collected.length;
+    collected = num[0];
+    i = collected.length;
   }
 
   collected = +collected;
@@ -491,7 +491,12 @@ function eatBag (input) {
   }
   input = input.slice(i + 1);
 
-  return [new Bag(collected), input];
+  if (exports.enableRIDBags) {
+    return [new Bag(collected), input];
+  }
+  else {
+    return [new Bag(collected).all(), input];
+  }
 }
 
 
@@ -521,7 +526,7 @@ function eatBinary (input) {
 }
 
 
-
+exports.enableRIDBags = true;
 exports.deserialize = deserialize;
 exports.eatKey = eatKey;
 exports.eatValue = eatValue;

--- a/test/core/bag-test.js
+++ b/test/core/bag-test.js
@@ -86,6 +86,18 @@ describe("RID Bag", function () {
         item.should.have.property('@rid');
       });
     });
+
+    describe('Optional RIDBags', function () {
+      before(function () {
+        this.db.server.transport.connection.protocol.deserializer.enableRIDBags = false;
+      });
+      after(function () {
+        this.db.server.transport.connection.protocol.deserializer.enableRIDBags = true;
+      });
+      it('should optionally disable RIDBags', function () {
+        Array.isArray(this.bag).should.be.true;
+      });
+    });
   });
 
   describe('Tree Bag', function () {


### PR DESCRIPTION
To disable RIDBags completely, use:

``` js
var server = Oriento({user: "root", password: "toot"});
server.transport.enableRIDBags = false;
```

> Note: This setting has no effect if a connection has already been established, so use this straight away after creating the server instance.
