### PR TITLE
Force preparation of bound parameters

### DIFF
--- a/lib/db/index.js
+++ b/lib/db/index.js
@@ -45,6 +45,7 @@ module.exports = Db;
  */
 Db.prototype.configure = function (config) {
   this.sessionId = config.sessionId != null ? config.sessionId : -1;
+  this.forcePrepare = config.forcePrepare != null ? config.forcePrepare : true;
   this.name = config.name;
 
   this.server = config.server;

--- a/lib/db/statement.js
+++ b/lib/db/statement.js
@@ -784,7 +784,7 @@ Statement.prototype._objectToSet = function (obj) {
     if (value instanceof RID) {
       expressions.push(key + ' = ' + value);
     }
-    else {
+    else if (value !== undefined) {
       paramName = 'param' + paramify(key) + (this._state.paramIndex++);
       expressions.push(key + ' = :' + paramName);
       this.addParam(paramName, value);

--- a/lib/db/statement.js
+++ b/lib/db/statement.js
@@ -498,7 +498,13 @@ Statement.prototype.buildStatement = function () {
         var child = new Statement(self.db);
         child._state.paramIndex = self._state.paramIndex;
         item[1](child);
-        return item[0] + ' = ' + child;
+        return item[0] + ' = (' + child + ')';
+      }
+      else if (item[1] instanceof Statement) {
+        return item[0] + ' = (' + item[1].toString() + ')';
+      }
+      else if (/\s/.test(item[1])) {
+        return item[0] + ' = (' + item[1] + ')';
       }
       else {
         return item[0] + ' = ' + item[1];

--- a/lib/transport/binary/protocol28/operations/command.js
+++ b/lib/transport/binary/protocol28/operations/command.js
@@ -4,7 +4,8 @@ var Operation = require('../operation'),
     constants = require('../constants'),
     serializer = require('../serializer'),
     writer = require('../writer'),
-    RID = require('../../../../recordid');
+    RID = require('../../../../recordid'),
+    utils = require('../../../../utils');
 
 module.exports = Operation.extend({
   id: 'REQUEST_COMMAND',
@@ -22,17 +23,25 @@ module.exports = Operation.extend({
   serializeQuery: function () {
     var buffers = [writer.writeString(this.data.class)];
 
+    var text = this.data.query;
+    var params = this.data.params;
+    // if there are bound parameters, force prepare them, OrientDB's support is limited in this version.
+    if (this.data.db && this.data.db.forcePrepare && params && params.params) {
+      text = utils.prepare(text, params.params);
+      params = undefined;
+    }
+
     if (this.data.class === 'q' ||
         this.data.class === 'com.orientechnologies.orient.core.sql.query.OSQLSynchQuery' ||
         this.data.class === 'com.orientechnologies.orient.core.sql.query.OSQLAsynchQuery') {
       buffers.push(
-        writer.writeString(this.data.query),
+        writer.writeString(text),
         writer.writeInt(this.data.limit),
         writer.writeString(this.data.fetchPlan || '')
       );
 
-      if (this.data.params) {
-        buffers.push(writer.writeString(serializeParams(this.data.params)));
+      if (params) {
+        buffers.push(writer.writeString(serializeParams(params)));
       }
       else {
         buffers.push(writer.writeInt(0));
@@ -43,12 +52,12 @@ module.exports = Operation.extend({
         this.data.class === 'com.orientechnologies.orient.core.command.script.OCommandScript') {
       buffers.push(
         writer.writeString(this.data.language || 'sql'),
-        writer.writeString(this.data.query)
+        writer.writeString(text)
       );
-      if (this.data.params && this.data.params.params && Object.keys(this.data.params.params).length) {
+      if (params && params.params && Object.keys(params.params).length) {
         buffers.push(
           writer.writeBoolean(true),
-          writer.writeString(serializeParams(this.data.params))
+          writer.writeString(serializeParams(params))
         );
       }
       else {
@@ -57,11 +66,11 @@ module.exports = Operation.extend({
       buffers.push(writer.writeByte(0));
     }
     else {
-      buffers.push(writer.writeString(this.data.query));
-      if (this.data.params) {
+      buffers.push(writer.writeString(text));
+      if (params) {
         buffers.push(
           writer.writeBoolean(true),
-          writer.writeString(serializeParams(this.data.params))
+          writer.writeString(serializeParams(params))
         );
       }
       else {

--- a/lib/transport/binary/protocol28/serializer.js
+++ b/lib/transport/binary/protocol28/serializer.js
@@ -20,6 +20,10 @@ function encodeRecordData (content) {
  * @return {String}           The serialized document.
  */
 function serializeDocument (document, isMap) {
+  if (typeof document.toOrient === 'function') {
+    document = document.toOrient();
+  }
+
   var result = '',
       className = '',
       fieldNames = Object.keys(document),
@@ -32,7 +36,7 @@ function serializeDocument (document, isMap) {
     if (field === '@class') {
       className = value;
     }
-    else if (field.charAt(0) === '@') {
+    else if (field.charAt(0) === '@' || value === undefined) {
       continue;
     }
     else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -171,7 +171,7 @@ function prepareArray (query, params) {
 function prepareObject (query, params) {
   var pattern = /"(\\[\s\S]|[^"])*"|'(\\[\s\S]|[^'])*'|([^A-Za-z0-9]:([A-Za-z][A-Za-z0-9_-]*))/g;
   return query.replace(pattern, function (all, double, single, char, param) {
-    if (param) {
+    if (param && params[param] !== undefined) {
       return char.charAt(0) + exports.encode(params[param]);
     }
     else {
@@ -204,6 +204,9 @@ exports.encode = function encode (value) {
   }
   else if (value instanceof RID) {
     return value.toString();
+  }
+  else if (typeof value.toOrient === 'function') {
+    return encode(value.toOrient());
   }
   else if (Array.isArray(value)) {
     return '[' + value.map(encode) + ']';
@@ -278,7 +281,7 @@ exports.deprecate = function (context, name, message, fn) {
 
 /**
  * Converts a date object to string observing OrientDB's default format
- * 
+ *
  * @param  {Date}   The value to convert
  * @return {String} The string formatted as 'yyyy-MM-dd HH:mm:ss'
  */
@@ -289,7 +292,7 @@ function getOrientDbUTCDate(date){
   var HH = pad(date.getUTCHours(), 2);
   var mm = pad(date.getUTCMinutes(), 2);
   var ss = pad(date.getUTCSeconds(), 2);
-  
+
   return yyyy + '-' + MM + '-' + dd + ' ' + HH + ':' + mm + ':' + ss;
 }
 

--- a/test/db/db-test.js
+++ b/test/db/db-test.js
@@ -179,6 +179,7 @@ describe("Database API", function () {
       });
 
       return this.db.select('name, status').from('OUser').limit(1).one()
+      .delay(10) // solves a strange race condition which happens about 1/20th of the time, needs further investigation.
       .then(function () {
         emitedObject.should.have.propertyByPath("perf", "query");
         emitedObject.perf.query.should.be.above(0);

--- a/test/db/statement-test.js
+++ b/test/db/statement-test.js
@@ -31,7 +31,7 @@ describe("Database API - Statement", function () {
       .let('names', sub)
       .buildStatement()
       .should
-      .equal('LET names = SELECT name FROM OUser WHERE status = "ACTIVE"');
+      .equal('LET names = (SELECT name FROM OUser WHERE status = "ACTIVE")');
     });
     it('should let a variable equal a subexpression, more than once', function () {
       var sub1 = (new Statement(this.db)).select('name').from('OUser').where({status: 'ACTIVE'}),
@@ -41,7 +41,7 @@ describe("Database API - Statement", function () {
       .let('statuses', sub2)
       .buildStatement()
       .should
-      .equal('LET names = SELECT name FROM OUser WHERE status = "ACTIVE",statuses = SELECT status FROM OUser');
+      .equal('LET names = (SELECT name FROM OUser WHERE status = "ACTIVE"),statuses = (SELECT status FROM OUser)');
     });
     it('should let a variable equal a subexpression, more than once, using locks', function () {
       var sub1 = (new Statement(this.db)).select('name').from('OUser').where({status: 'ACTIVE'}),
@@ -51,7 +51,7 @@ describe("Database API - Statement", function () {
       .let('statuses', sub2)
       .buildStatement()
       .should
-      .equal('LET names = SELECT name FROM OUser WHERE status = "ACTIVE",statuses = SELECT status FROM OUser LOCK record');
+      .equal('LET names = (SELECT name FROM OUser WHERE status = "ACTIVE"),statuses = (SELECT status FROM OUser LOCK record)');
     });
 
     it('should allow RIDs in LET expressions', function () {


### PR DESCRIPTION
OrientDB's lack of full support for nested-bound-parameters is an endless source of frustration for users of Oriento. With this PR, by default, parameters are now bound before being passed to OrientDB. This is a potentially breaking change, so it can be disabled by setting `db.forcePrepare = false`. 

Fixes #220 and #226 