### PR TITLE
Escape fixes

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -129,10 +129,30 @@ exports.clone = function (item) {
  * @return {String}       The escaped input.
  */
 exports.escape = function (input) {
-  return ('' + input)
-  .replace(/\r/g, '\\r')
-  .replace(/\n/g, '\\n')
-  .replace(/([^"\\]*(?:\\.[^"\\]*)*)"/g, '$1\\"');
+  var text = ''+input;
+  var chars = new Array(text.length);
+  for (var i = 0; i < text.length; i++) {
+    var char = text.charAt(i);
+    if (char === '\r') {
+      chars[i] = '\\r';
+    }
+    else if (char === '\n') {
+      chars[i] = '\\n';
+    }
+    else if (char === '"') {
+      chars[i] = '\\"';
+    }
+    else if (char === '\\') {
+     chars[i] = '\\\\';
+    }
+    else if (char === '/' && i === 0) {
+     chars[i] = '\\/';
+    }
+    else {
+      chars[i] = char;
+    }
+  }
+  return chars.join('');
 };
 
 /**

--- a/test/bugs/xxx-link-when-create-edge.js
+++ b/test/bugs/xxx-link-when-create-edge.js
@@ -1,0 +1,81 @@
+var Bluebird = require('bluebird');
+
+describe("Bug: Should create a link while inserting an edge", function () {
+  var first, second, third;
+  before(function () {
+    return CREATE_TEST_DB(this, 'testdb_bug_edge_link')
+    .bind(this)
+    .then(function () {
+      return Bluebird.all([
+        this.db.class.create('Thing', 'V'),
+        this.db.class.create('Knows', 'E')
+      ]);
+    })
+    .spread(function (Thing, Knows) {
+      return Bluebird.all([
+        Thing.property.create([
+          {
+            name: 'name',
+            type: 'string'
+          }
+        ]),
+        Knows.property.create([
+          {
+            name: 'referrer',
+            type: 'link'
+          }
+        ])
+      ]);
+    })
+    .then(function () {
+      return this.db
+      .let('first', "CREATE VERTEX Thing SET name = 'first'")
+      .let('second', "CREATE VERTEX Thing SET name = 'second'")
+      .let('third', "CREATE VERTEX Thing SET name = 'third'")
+      .return(['$first', '$second', '$third'])
+      .commit()
+      .all()
+      .then(function (results) {
+        first = results[0];
+        second = results[1];
+        third = results[2];
+      });
+    });
+  });
+  after(function () {
+    return DELETE_TEST_DB('testdb_bug_edge_link');
+  });
+  it('should create a link whilst creating an edge', function () {
+    return this.db
+    .create('EDGE', 'Knows')
+    .from(first['@rid'])
+    .to(second['@rid'])
+    .set({
+      referrer: third['@rid']
+    })
+    .one()
+    .then(function (result) {
+      result.referrer.equals(third['@rid']).should.be.true;
+    })
+  });
+
+  it('should create a link whilst creating an edge in a transaction', function () {
+    return this.db
+    .let('fourth', "CREATE VERTEX Thing SET name = 'fourth'")
+    .let('fifth', "CREATE VERTEX Thing SET name = 'fifth'")
+    .let('sixth', "CREATE VERTEX Thing SET name = 'sixth'")
+    .let('knows', function (s) {
+      s
+      .create('EDGE', 'Knows')
+      .from('$fourth')
+      .to('$fifth')
+      .set('referrer = first($sixth)')
+    })
+    .return(['$sixth', '$knows'])
+    .commit()
+    .all()
+    .spread(function (referrer, edge) {
+      edge.referrer.should.equal(referrer);
+    });
+  });
+});

--- a/test/core/utils.js
+++ b/test/core/utils.js
@@ -9,6 +9,12 @@ describe('utils.prepare', function () {
   it("should prepare SQL statements with parameters", function () {
     utils.prepare("select from index:foo where key = :key", {key: 123}).should.equal("select from index:foo where key = 123");
   });
+  it('should prepare SQL statements with parameters with tricky values', function () {
+    var text = utils.prepare("SELECT * FROM OUser WHERE foo = :foo", {
+      foo: '/// TE /// ST \\\\\\'
+    });
+    text.should.equal('SELECT * FROM OUser WHERE foo = "\\/// TE /// ST \\\\\\\\\\\\"');
+  });
   it("should prepare SQL statements with date parameters", function () {
     var date = new Date(Date.UTC(2015, 0, 5, 22, 7, 5));
     utils.prepare("select from index:foo where date = :date", {date: date}).should.equal("select from index:foo where date = date(\"2015-01-05 22:07:05\", \"yyyy-MM-dd HH:mm:ss\", \"UTC\")");


### PR DESCRIPTION
Due to some quirks in OrientDB's current SQL parser, we need to use a state machine to escape content rather than a regex, happily this is also faster than the original code.