### PR TITLE
allow database connection to not require a server-wide connection

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -143,6 +143,14 @@ Server.prototype.use = function (config) {
   }
   else {
     config.server = this;
+    if (config.username) {
+      this.transport.username = config.username;
+      this.transport.skipServerConnect = true;
+    }
+    if (config.password) {
+      this.transport.password = config.password;
+      this.transport.skipServerConnect = true;
+    }
   }
 
   if (!config.name) {

--- a/lib/transport/binary/index.js
+++ b/lib/transport/binary/index.js
@@ -139,6 +139,10 @@ BinaryTransport.prototype.connect = function () {
     return Promise.resolve(this);
   }
 
+  if (this.skipServerConnect) {
+    return Promise.resolve(this).bind(this);
+  }
+
   if (this.connecting) {
     if (this.connecting.isRejected()) {
       return new Promise(function (resolve, reject) {

--- a/test/bugs/169-connect-directly-to-database.js
+++ b/test/bugs/169-connect-directly-to-database.js
@@ -1,0 +1,30 @@
+describe("Bug #169: Connect to db without server credentials", function () {
+  var server, db;
+  before(function () {
+    server = new LIB.Server({
+      host: TEST_SERVER_CONFIG.host,
+      port: TEST_SERVER_CONFIG.port,
+      username: 'nope',
+      password: 'nope',
+      transport: 'binary',
+      useToken: false
+    });    
+    return CREATE_TEST_DB(this, 'testdb_bug_169')
+    .then(function () {
+      db = server.use({
+        name: 'testdb_bug_169',
+        username: 'admin',
+        password: 'admin'
+      });
+    });
+  });
+  after(function () {
+    return DELETE_TEST_DB('testdb_bug_169');
+  });
+  it('should connect to the database directly', function () {
+    return db.select().from('OUser').all()
+    .then(function (results) {
+      results.length.should.be.above(0);
+    });
+  });
+});


### PR DESCRIPTION
This pull request has `server.use` check for database credentials. If so, it assumes that the transport hasn't connected yet, and configures it to skip attempting the `REQUEST_CONNECT` operation. 

closes #169