### PR TITLE
add migrate command for direct database connections

### DIFF
--- a/lib/cli/commands/migrate.js
+++ b/lib/cli/commands/migrate.js
@@ -7,7 +7,7 @@ var path = require('path'),
  * The required CLI arguments for the command.
  * @type {Array}
  */
-exports.requiredArgv = ['dbname', 'password'];
+exports.requiredArgv = ['dbname', 'password|dbpassword'];
 
 /**
  * Get the migration manager instance

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -33,8 +33,15 @@ CLI.prototype.run = function (argv) {
     command = this.createCommand(command, argv);
     total = command.requiredArgv.length;
     for (i = 0; i < total; i++) {
-      if (argv[command.requiredArgv[i]] === undefined) {
-        yargs.demand(command.requiredArgv[i]);
+      var possibleOpts = command.requiredArgv[i].split('|');
+      var found = false;
+      for (var j = 0; j < possibleOpts.length; ++j) {
+        if (argv[possibleOpts[j]] !== undefined) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
         return command.help();
       }
     }
@@ -54,6 +61,7 @@ CLI.prototype.createCommand = function (name, argv) {
   try {
     var Constructor = Command.extend(require(filename)),
         server = this.createServer(argv);
+
 
     return new Constructor(server, argv);
   }


### PR DESCRIPTION
This makes it so that migrate can use a direct database connection by optionally requiring one of two argv arguments