### PR TITLE
Bad default config for class properties

### DIFF
--- a/lib/db/class/property.js
+++ b/lib/db/class/property.js
@@ -35,8 +35,8 @@ Property.prototype.configure = function (config) {
   this.readonly = config.readonly || false;
   this.notNull = config.notNull || false;
   this.collate = config.collate || 'default';
-  this.min = config.min || null;
-  this.max = config.max || null;
+  this.min = typeof config.min !== 'undefined' ? config.min : null;
+  this.max = typeof config.max !== 'undefined' ? config.max : null;
   this.regexp = config.regexp || null;
   this.linkedClass = config.linkedClass || null;
   if (config.custom && config.custom.fields) {


### PR DESCRIPTION
Your current implementation for default value will replace valid number 0 to null because 
0 || null => null