### PR TITLE
Escaping / (forward slash) causes SQL errors

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -145,9 +145,6 @@ exports.escape = function (input) {
     else if (char === '\\') {
      chars[i] = '\\\\';
     }
-    else if (char === '/' && i === 0) {
-     chars[i] = '\\/';
-    }
     else {
       chars[i] = char;
     }

--- a/test/bugs/329-pullreq-do-not-escape-slash.js
+++ b/test/bugs/329-pullreq-do-not-escape-slash.js
@@ -1,0 +1,22 @@
+describe('Pull Request #329: Not escaping leading forward slash "(/)"', function () {
+  before(function () {
+    return CREATE_TEST_DB(this, 'testdb_PR_329');
+  });
+  after(function () {
+    return DELETE_TEST_DB('testdb_PR_329');
+  });
+  it('should still enable inserting record with field like "/// TE /// ST \\\\\\"', function () {
+    return this.db.insert().into('v').set({val: '/// TE /// ST \\\\\\'}).one()
+    .then(function (result) {
+      result.val.should.equal('/// TE /// ST \\\\\\');
+    });
+  });
+
+  it('should still enable where clause with field like "/// TE /// ST \\\\\\"', function () {
+    return this.db.select().from('v').where({val: '/// TE /// ST \\\\\\'}).one()
+    .then(function (result) {
+      result.val.should.equal('/// TE /// ST \\\\\\');
+    });
+  });
+
+});

--- a/test/core/utils.js
+++ b/test/core/utils.js
@@ -9,12 +9,6 @@ describe('utils.prepare', function () {
   it("should prepare SQL statements with parameters", function () {
     utils.prepare("select from index:foo where key = :key", {key: 123}).should.equal("select from index:foo where key = 123");
   });
-  it('should prepare SQL statements with parameters with tricky values', function () {
-    var text = utils.prepare("SELECT * FROM OUser WHERE foo = :foo", {
-      foo: '/// TE /// ST \\\\\\'
-    });
-    text.should.equal('SELECT * FROM OUser WHERE foo = "\\/// TE /// ST \\\\\\\\\\\\"');
-  });
   it("should prepare SQL statements with date parameters", function () {
     var date = new Date(Date.UTC(2015, 0, 5, 22, 7, 5, 435));
     utils.prepare("select from index:foo where date = :date", {date: date}).should.equal("select from index:foo where date = date(\"2015-01-05 22:07:05.435\", \"yyyy-MM-dd HH:mm:ss.SSS\", \"UTC\")");


### PR DESCRIPTION
I couldn't figure out if there was a reason that a leading / (forward slash) is being escaped. However, because of this, trying to save a value that begins with a forward slash causes a lexical error in the SQL. (OreintDB 2.1 rc3).